### PR TITLE
Create directory of `pocket-lib-token-file` if it doesn't exist

### DIFF
--- a/README.org
+++ b/README.org
@@ -18,10 +18,11 @@ Put =pocket-lib.el= in your =load-path=.
 
 First you must authorize this library to access your Pocket account.
 
-1.  Open your web browser to the Pocket web site, and log out of Pocket.  (It seems to only work if you are logged out.)
-2.  Run =pocket-lib-get= (this is not an interactive command, so you should call it in the minibuffer like ~(pocket-lib-get)~; typically this will be handled for you by packages that use this library).  A URL will be copied to the clipboard and kill-ring.
-3.  Visit that URL in your browser, and authorize it.
-4.  Run =pocket-lib-get= again.  If it worked, you should see an ugly list of data containing the first 10 items on your list.
+1. Make sure the directory of =pocket-lib-token-file= exists.  If it doesn't then either create the directory or set =pocket-lib-token-file= to a file in an existing directory.
+2. Open your web browser to the Pocket web site, and log out of Pocket.  (It seems to only work if you are logged out.)
+3. Run =pocket-lib-get= (this is not an interactive command, so you should call it in the minibuffer like ~(pocket-lib-get)~; typically this will be handled for you by packages that use this library).  A URL will be copied to the clipboard and kill-ring.
+4. Visit that URL in your browser, and authorize it.
+5. Run =pocket-lib-get= again.  If it worked, you should see an ugly list of data containing the first 10 items on your list.
 
 Now you can use the library.
 

--- a/README.org
+++ b/README.org
@@ -51,7 +51,11 @@ These functions operate on one or more items, which should be alists, structured
 
 *Changes*
 
-+  Use [[https://github.com/alphapapa/plz.el][plz]] HTTP library.
++ Use [[https://github.com/alphapapa/plz.el][plz]] HTTP library.
+
+*Fixes*
+
++ Ensure token file is writable.  ([[https://github.com/alphapapa/pocket-lib.el/pull/1][#1]].  Thanks to [[https://github.com/alphapapa/pocket-lib.el/issues?q=is%3Apr+is%3Aopen+author%3Akevinjfoley][Kevin Foley]].)
 
 ** v0.2
 

--- a/README.org
+++ b/README.org
@@ -18,11 +18,10 @@ Put =pocket-lib.el= in your =load-path=.
 
 First you must authorize this library to access your Pocket account.
 
-1. Make sure the directory of =pocket-lib-token-file= exists.  If it doesn't then either create the directory or set =pocket-lib-token-file= to a file in an existing directory.
-2. Open your web browser to the Pocket web site, and log out of Pocket.  (It seems to only work if you are logged out.)
-3. Run =pocket-lib-get= (this is not an interactive command, so you should call it in the minibuffer like ~(pocket-lib-get)~; typically this will be handled for you by packages that use this library).  A URL will be copied to the clipboard and kill-ring.
-4. Visit that URL in your browser, and authorize it.
-5. Run =pocket-lib-get= again.  If it worked, you should see an ugly list of data containing the first 10 items on your list.
+1.  Open your web browser to the Pocket web site, and log out of Pocket.  (It seems to only work if you are logged out.)
+2.  Run =pocket-lib-get= (this is not an interactive command, so you should call it in the minibuffer like ~(pocket-lib-get)~; typically this will be handled for you by packages that use this library).  A URL will be copied to the clipboard and kill-ring.
+3.  Visit that URL in your browser, and authorize it.
+4.  Run =pocket-lib-get= again.  If it worked, you should see an ugly list of data containing the first 10 items on your list.
 
 Now you can use the library.
 

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -104,8 +104,8 @@ If token already exists, don't get a new one, unless FORCE is non-nil."
 (cl-defun pocket-lib--request-token (&key force)
   "Return request token.
 If no token exists, or if FORCE is non-nil, get a new token."
-  (unless (file-writeable-p (file-name-directory pocket-lib-token-file))
-    (user-error "Token file directory doesn't exist. Either create directory first or change value of `pocket-lib-token-file'"))
+  (unless (file-writable-p pocket-lib-token-file)
+    (error "pocket-lib: Token file %S not writable" pocket-lib-token-file))
   (when (or (not pocket-lib--request-token)
             force)
     (condition-case err

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -104,6 +104,8 @@ If token already exists, don't get a new one, unless FORCE is non-nil."
 (cl-defun pocket-lib--request-token (&key force)
   "Return request token.
 If no token exists, or if FORCE is non-nil, get a new token."
+  (unless (file-writeable-p (file-name-directory pocket-lib-token-file))
+    (user-error "Token file directory doesn't exist. Either create directory first or change value of `pocket-lib-token-file'"))
   (when (or (not pocket-lib--request-token)
             force)
     (condition-case err


### PR DESCRIPTION
`with-temp-file` throws error if the directory of the file doesn't exist