### PR TITLE
Fix login loop

### DIFF
--- a/README.org
+++ b/README.org
@@ -57,6 +57,10 @@ These functions operate on one or more items, which should be alists, structured
 
 + Ensure token file is writable.  ([[https://github.com/alphapapa/pocket-lib.el/pull/1][#1]].  Thanks to [[https://github.com/alphapapa/pocket-lib.el/issues?q=is%3Apr+is%3Aopen+author%3Akevinjfoley][Kevin Foley]].)
 
+*Acknowledgments*
+
++ Thanks to [[https://github.com/joshbax189][Josh B]] for reporting and helping to fix a bug with initial authentication.
+
 ** v0.2
 
 *Changes*

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -49,7 +49,6 @@
 ;;;; Variables
 
 (defvar pocket-lib--access-token-have-opened-browser nil)
-(defvar pocket-lib--request-token nil)
 (defvar pocket-lib--access-token nil)
 (defconst pocket-lib-default-extra-headers
   '(("Host" . "getpocket.com")
@@ -100,8 +99,7 @@ Sets token in variable `pocket-lib--access-token'."
   (setq pocket-lib--access-token token))
 
 (defun pocket-lib--request-token ()
-  "Return and set new request token.
-Sets token in variable `pocket-lib--request-token'."
+  "Return new request token."
   (unless (file-writable-p pocket-lib-token-file)
     (error "pocket-lib: Token file %S not writable" pocket-lib-token-file))
   (condition-case err
@@ -109,9 +107,8 @@ Sets token in variable `pocket-lib--request-token'."
                      :data (list :redirect_uri "http://www.example.com")
                      :no-auth t))
              (token (alist-get 'code data)))
-        (unless token
-          (error "No token received: %S" data))
-        (setq pocket-lib--request-token token))
+        (or token
+            (error "No token received: %S" data)))
     (error (error "pocket-lib: Unable to get request token: %s" err))))
 
 (cl-defun pocket-lib--access-token (request-token &key force)
@@ -141,8 +138,7 @@ If FORCE is non-nil, get a new token."
   "Reset all saved auth tokens.
 This should not be necessary unless something has gone wrong."
   (interactive)
-  (setq pocket-lib--request-token nil
-        pocket-lib--access-token nil
+  (setq pocket-lib--access-token nil
         pocket-lib--access-token-have-opened-browser nil)
   (with-temp-file pocket-lib-token-file
     nil))

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -111,7 +111,7 @@ If no token exists, or if FORCE is non-nil, get a new token."
       (condition-case err
           (let* ((data (pocket-lib--request 'oauth/request
                          :data (list :redirect_uri "http://www.example.com")
-                         :no-auth 't))
+                         :no-auth t))
                  (token (alist-get 'code data)))
             (unless token
               (error "No token"))
@@ -132,7 +132,7 @@ If FORCE is non-nil, get a new token."
             (or (condition-case err
                     (or (pocket-lib--request 'oauth/authorize
                           :data (list :code request-token)
-                          :no-auth 't)
+                          :no-auth t)
                         (error "No data"))
                   (error (error "pocket-lib--access-token: Unable to get access token: %S" err))))
           ;; Not authorized yet, or forcing; browse to authorize

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -110,7 +110,8 @@ If no token exists, or if FORCE is non-nil, get a new token."
             force)
     (condition-case err
         (let* ((data (pocket-lib--request 'oauth/request
-                       :data (list :redirect_uri "http://www.example.com")))
+                       :data (list :redirect_uri "http://www.example.com")
+                       :no-auth 't))
                (token (alist-get 'code data)))
           (unless token
             (error "No token"))
@@ -128,7 +129,8 @@ If FORCE is non-nil, get a new token."
             ;; Already authorized in browser; try to get token
             (or (condition-case err
                     (or (pocket-lib--request 'oauth/authorize
-                          :data (list :code request-token))
+                          :data (list :code request-token)
+                          :no-auth 't)
                         (error "No data"))
                   (error (error "pocket-lib--access-token: Unable to get access token: %S" err))))
           ;; Not authorized yet, or forcing; browse to authorize

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -74,77 +74,68 @@
 
 ;;;;; Authorization
 
-(cl-defun pocket-lib--authorize (&key force)
-  "Get and save authorization token.
-If token already exists, don't get a new one, unless FORCE is non-nil."
-  (when (or (null pocket-lib--access-token)
-            force)
-    (unless force
-      ;; Try to load from file
-      (pocket-lib--load-access-token))
-    (when (or (null pocket-lib--access-token) force)
-      ;; Get new token
-      (if-let ((request-token (pocket-lib--request-token :force force))
-               (access-token (pocket-lib--access-token request-token :force force)))
-          (pocket-lib--save-access-token access-token)
-        (error "Unable to authorize (request-token:%s)" request-token)))))
+(defun pocket-lib--authorize (&optional forcep)
+  "Load or request access token and set it.
+If FORCEP, ignore a saved token and request a new one; otherwise
+request a new one only if a saved one is not available.  Sets
+token in variable `pocket-lib--access-token'."
+  (when (or forcep (null (pocket-lib--load-access-token)))
+    (if-let ((request-token (pocket-lib--request-token))
+             (access-token (pocket-lib--access-token request-token :force forcep)))
+        (pocket-lib--save-access-token access-token)
+      (error "Unable to authorize (request-token:%s)" request-token))))
 
 (defun pocket-lib--load-access-token ()
-  "Load access token from `pocket-lib-token-file'."
+  "Load and return access token from `pocket-lib-token-file'.
+Sets token in variable `pocket-lib--access-token'."
   (when (file-readable-p pocket-lib-token-file)
     (setq pocket-lib--access-token (ignore-errors
                                      (json-read-file pocket-lib-token-file)))))
 
 (defun pocket-lib--save-access-token (token)
-  "Write TOKEN to `pocket-lib-token-file' and set variable."
+  "Write TOKEN to `pocket-lib-token-file' and set variable.
+Sets token in variable `pocket-lib--access-token'."
   (with-temp-file pocket-lib-token-file
     (insert (json-encode-alist token)))
   (setq pocket-lib--access-token token))
 
-(cl-defun pocket-lib--request-token (&key force)
-  "Return request token.
-If no token exists, or if FORCE is non-nil, get a new token."
+(defun pocket-lib--request-token ()
+  "Return and set new request token.
+Sets token in variable `pocket-lib--request-token'."
   (unless (file-writable-p pocket-lib-token-file)
     (error "pocket-lib: Token file %S not writable" pocket-lib-token-file))
-  (if (or (not pocket-lib--request-token)
-          force)
-      (condition-case err
-          (let* ((data (pocket-lib--request 'oauth/request
-                         :data (list :redirect_uri "http://www.example.com")
-                         :no-auth t))
-                 (token (alist-get 'code data)))
-            (unless token
-              (error "No token"))
-            (setq pocket-lib--request-token token))
-        (error (error "pocket-lib: Unable to get request token: %s" err)))
-    ;; otherwise return the saved token
-    pocket-lib--request-token))
+  (condition-case err
+      (let* ((data (pocket-lib--request 'oauth/request
+                     :data (list :redirect_uri "http://www.example.com")
+                     :no-auth t))
+             (token (alist-get 'code data)))
+        (unless token
+          (error "No token received: %S" data))
+        (setq pocket-lib--request-token token))
+    (error (error "pocket-lib: Unable to get request token: %s" err))))
 
 (cl-defun pocket-lib--access-token (request-token &key force)
   "Return access token retrieved with REQUEST-TOKEN.
 If FORCE is non-nil, get a new token."
-  (if (or (null pocket-lib--access-token)
-          force)
-      (progn
-        (if (and pocket-lib--access-token-have-opened-browser
-                 (not force))
-            ;; Already authorized in browser; try to get token
-            (or (condition-case err
-                    (or (pocket-lib--request 'oauth/authorize
-                          :data (list :code request-token)
-                          :no-auth t)
-                        (error "No data"))
-                  (error (error "pocket-lib--access-token: Unable to get access token: %S" err))))
-          ;; Not authorized yet, or forcing; browse to authorize
-          ;; FIXME: Is this a nice way to do this?
-          (let ((url (concat "https://getpocket.com/auth/authorize?request_token=" request-token)))
-            ;; NOTE: Doing it in w3m doesn't seem to work.  It only
-            ;;  seems to work in a regular browser, and then only when
-            ;;  the user is logged out of Pocket when he accesses the
-            ;;  auth URL.  (browse-url url)
-            (kill-new url))
-          (setq pocket-lib--access-token-have-opened-browser t)
-          (user-error "pocket-lib must be authorized first.  Please open your Web browser to the URL in the clipboard/kill-ring and follow the instructions, then try again")))))
+  (if (and pocket-lib--access-token-have-opened-browser
+           (not force))
+      ;; Already authorized in browser; try to get token
+      (or (condition-case err
+              (or (pocket-lib--request 'oauth/authorize
+                    :data (list :code request-token)
+                    :no-auth t)
+                  (error "No data"))
+            (error (error "pocket-lib--access-token: Unable to get access token: %S" err))))
+    ;; Not authorized yet, or forcing; browse to authorize
+    ;; FIXME: Is this a nice way to do this?
+    (let ((url (concat "https://getpocket.com/auth/authorize?request_token=" request-token)))
+      ;; NOTE: Doing it in w3m doesn't seem to work.  It only
+      ;;  seems to work in a regular browser, and then only when
+      ;;  the user is logged out of Pocket when he accesses the
+      ;;  auth URL.  (browse-url url)
+      (kill-new url))
+    (setq pocket-lib--access-token-have-opened-browser t)
+    (user-error "pocket-lib must be authorized first.  Please open your Web browser to the URL in the clipboard/kill-ring and follow the instructions, then try again")))
 
 (defun pocket-lib-reset-auth ()
   "Reset all saved auth tokens.

--- a/pocket-lib.el
+++ b/pocket-lib.el
@@ -106,17 +106,19 @@ If token already exists, don't get a new one, unless FORCE is non-nil."
 If no token exists, or if FORCE is non-nil, get a new token."
   (unless (file-writable-p pocket-lib-token-file)
     (error "pocket-lib: Token file %S not writable" pocket-lib-token-file))
-  (when (or (not pocket-lib--request-token)
-            force)
-    (condition-case err
-        (let* ((data (pocket-lib--request 'oauth/request
-                       :data (list :redirect_uri "http://www.example.com")
-                       :no-auth 't))
-               (token (alist-get 'code data)))
-          (unless token
-            (error "No token"))
-          (setq pocket-lib--request-token token))
-      (error (error "pocket-lib: Unable to get request token: %s" err)))))
+  (if (or (not pocket-lib--request-token)
+          force)
+      (condition-case err
+          (let* ((data (pocket-lib--request 'oauth/request
+                         :data (list :redirect_uri "http://www.example.com")
+                         :no-auth 't))
+                 (token (alist-get 'code data)))
+            (unless token
+              (error "No token"))
+            (setq pocket-lib--request-token token))
+        (error (error "pocket-lib: Unable to get request token: %s" err)))
+    ;; otherwise return the saved token
+    pocket-lib--request-token))
 
 (cl-defun pocket-lib--access-token (request-token &key force)
   "Return access token retrieved with REQUEST-TOKEN.


### PR DESCRIPTION
**Bug**

When initially logging in using `pocket-lib-get`, I get the following error:
```
(error "pocket-lib: Unable to get request token: (error pocket-lib: Unable to get request token: (error pocket-lib: Unable to get 
...
pocket-lib: Unable to get request token: (excessive-lisp-nesting 1601)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))")
```

**Cause**

It seems that `pocket-lib--authorize` calls `pocket-lib--request` which calls `pocket-lib--authorize`

**Fix**
The inner calls (in `pocket-lib--request-token` and `pocket-lib--access-token`) should pass `:no-auth 't` to break the loop.

Also, `pocket-lib--request-token` should return the cached token when present, otherwise it passes `nil` to `pocket-lib--access-token`.

**Tests**

After applying the fixes, the authorization instructions work as described.

Here are some ERTs that illustrate the problems and fixes
```elisp
(require 'ert)
(require 'pocket-lib)

;; should return the token, but loops
(ert-deftest pocket-lib--request-token-test-initial ()
  "Should return a string token on initial run."
  (setq pocket-lib--request-token nil) ;; could do (pocket-lib-reset-auth)
  (should (stringp (pocket-lib--request-token))))

;; should return cached token, but returns nil
(ert-deftest pocket-lib--request-token-test-cached ()
  "Should return the cached token."
  (let ((cached-token "foo"))
    (setq pocket-lib--request-token cached-token)
   (should (equal cached-token (pocket-lib--request-token)))))

;; works as is
(ert-deftest pocket-lib--access-token-test-initial ()
  "Should put url in the kill ring."
  (let ((request-token "foo"))
    (setq pocket-lib--access-token nil)
    (setq pocket-lib--access-token-have-opened-browser nil)

    (should-error (pocket-lib--access-token request-token))
    (should (equal (concat "https://getpocket.com/auth/authorize?request_token=" request-token) (car kill-ring)))))

;; should raise with "bad token", but loops
(ert-deftest pocket-lib--access-token-test-repeat ()
  "Should authorize."
  (let ((request-token "foo"))
    (setq pocket-lib--access-token nil)
    (setq pocket-lib--access-token-have-opened-browser 't)

    (let ((err (should-error (pocket-lib--access-token request-token))))
      (should (string-prefix-p "pocket-lib--access-token: Unable to get access token" (nth 1 err))))))
```